### PR TITLE
replaced compile with implementation

### DIFF
--- a/ANDROID_INSTRUCTIONS.md
+++ b/ANDROID_INSTRUCTIONS.md
@@ -17,7 +17,7 @@ project(':react-native-share-menu').projectDir = new File(rootProject.projectDir
 ...
 dependencies {
     ...
-    compile project(':react-native-share-menu')
+    implementation project(':react-native-share-menu')
 }
 ```
 


### PR DESCRIPTION
newer versions of react native give the following error:
 
```log
A problem occurred evaluating project ':app'.
> Could not find method compile() for arguments [project ':react-native-share-menu'] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```